### PR TITLE
feat: rerun backtest from portfolio settings

### DIFF
--- a/src/api/endpoints/portfolios.ts
+++ b/src/api/endpoints/portfolios.ts
@@ -67,7 +67,7 @@ export function deletePortfolio(slug: string): Promise<void> {
 }
 
 export function triggerPortfolioRun(slug: string): Promise<BacktestRun> {
-  return apiClient<BacktestRun>(`/portfolios/${slug}/runs`, { method: 'POST' })
+  return apiClient<BacktestRun>(`/portfolios/${slug}/run`, { method: 'POST' })
 }
 
 export function getPortfolioRun(slug: string, runId: string): Promise<BacktestRun> {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -110,6 +110,25 @@ export const handlers = [
     return new HttpResponse(null, { status: 204 })
   }),
 
+  http.post(`${base}/portfolios/:slug/run`, ({ params }) => {
+    const slug = typeof params.slug === 'string' ? params.slug : String(params.slug)
+    if (!(slug in portfolioMap)) {
+      return HttpResponse.json(
+        { title: 'Not Found', status: 404 },
+        { status: 404, headers: { 'content-type': 'application/problem+json' } }
+      )
+    }
+    return HttpResponse.json(
+      {
+        id: crypto.randomUUID(),
+        portfolioSlug: slug,
+        status: 'queued',
+        startedAt: new Date().toISOString()
+      },
+      { status: 202 }
+    )
+  }),
+
   http.get(`${base}/portfolios/:slug/runs/:runId/progress`, () => {
     const totalSteps = 8
     const stepMs = 400

--- a/src/pages/PortfolioSettings.vue
+++ b/src/pages/PortfolioSettings.vue
@@ -8,8 +8,10 @@ import { usePortfolioAlerts } from '@/composables/usePortfolioAlerts'
 import {
   updatePortfolio,
   deletePortfolio,
-  sendPortfolioEmailSummary
+  sendPortfolioEmailSummary,
+  triggerPortfolioRun
 } from '@/api/endpoints/portfolios'
+import { usePortfolioRunProgress } from '@/composables/usePortfolioRunProgress'
 import {
   createPortfolioAlert,
   updatePortfolioAlert,
@@ -71,6 +73,42 @@ async function onRename() {
     renameError.value = (e as Error).message
   } finally {
     renaming.value = false
+  }
+}
+
+// --- Rerun ---
+type RunState = 'idle' | 'running' | 'done' | 'error'
+const runState = ref<RunState>('idle')
+const runError = ref<string | null>(null)
+
+const { progressPct, start: startRunProgress } = usePortfolioRunProgress({
+  onSuccess: async () => {
+    const slug = portfolioId.value
+    if (slug) {
+      await queryClient.invalidateQueries({ queryKey: ['portfolio', slug] })
+      await queryClient.invalidateQueries({ queryKey: ['portfolios'] })
+    }
+    runState.value = 'done'
+    setTimeout(() => {
+      if (runState.value === 'done') runState.value = 'idle'
+    }, 4000)
+  },
+  onFailure: (msg) => {
+    runError.value = msg
+    runState.value = 'error'
+  }
+})
+
+async function onRerun() {
+  if (!portfolioId.value || runState.value === 'running') return
+  runState.value = 'running'
+  runError.value = null
+  try {
+    const run = await triggerPortfolioRun(portfolioId.value)
+    await startRunProgress(portfolioId.value, run.id)
+  } catch (e) {
+    runError.value = (e as Error).message
+    runState.value = 'error'
   }
 }
 
@@ -325,14 +363,44 @@ async function onSendEmail() {
       </div>
     </section>
 
-    <!-- Q2: Details -->
+    <!-- Q2: Details + Rerun -->
     <section class="ps-card ps-q2">
-      <div class="ps-section-label">Details</div>
-      <div class="ps-kv-list">
-        <div v-for="row in infoRows" :key="row.label" class="ps-kv-row">
-          <span class="ps-kv-key">{{ row.label }}</span>
-          <span class="ps-kv-val" :class="{ mono: row.mono }">{{ row.value }}</span>
+      <div class="ps-subsection ps-subsection--grow">
+        <div class="ps-section-label">Details</div>
+        <div class="ps-kv-list">
+          <div v-for="row in infoRows" :key="row.label" class="ps-kv-row">
+            <span class="ps-kv-key">{{ row.label }}</span>
+            <span class="ps-kv-val" :class="{ mono: row.mono }">{{ row.value }}</span>
+          </div>
         </div>
+      </div>
+
+      <div class="ps-subsection-divider" />
+
+      <div class="ps-subsection">
+        <div class="ps-section-label">Run backtest</div>
+        <p class="ps-section-desc">
+          Re-run this portfolio against the latest market data. New holdings, transactions, and
+          statistics replace the current snapshot.
+        </p>
+        <div class="ps-run-row">
+          <button
+            type="button"
+            class="ps-btn ps-btn--primary"
+            :disabled="runState === 'running'"
+            @click="onRerun"
+          >
+            {{ runState === 'running' ? 'Running…' : 'Rerun' }}
+          </button>
+          <div v-if="runState === 'running'" class="ps-run-progress">
+            <div class="ps-run-track">
+              <div class="ps-run-bar" :style="{ width: progressPct + '%' }" />
+            </div>
+            <span class="ps-run-pct">{{ progressPct }}%</span>
+          </div>
+        </div>
+        <p v-if="runState === 'done'" class="ps-ok">Run completed. Portfolio updated.</p>
+        <p v-if="runState === 'error' && runError" class="ps-err">{{ runError }}</p>
       </div>
     </section>
 
@@ -666,8 +734,9 @@ async function onSendEmail() {
   color: color-mix(in srgb, var(--loss) 70%, var(--text-3));
 }
 
-/* ── Q1: two subsections stacked ───────────────────── */
-.ps-q1 {
+/* ── Q1/Q2: two subsections stacked ────────────────── */
+.ps-q1,
+.ps-q2 {
   display: flex;
   flex-direction: column;
 }
@@ -728,6 +797,50 @@ async function onSendEmail() {
   font-family: 'IBM Plex Mono', ui-monospace, monospace;
   font-size: 12px;
   letter-spacing: 0.01em;
+}
+
+/* ── Run backtest ──────────────────────────────────── */
+.ps-run-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ps-run-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.ps-run-track {
+  flex: 1;
+  height: 3px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.ps-run-bar {
+  height: 100%;
+  width: 0%;
+  background: var(--primary);
+  border-radius: 2px;
+  transition: width 400ms ease;
+}
+
+.ps-run-pct {
+  font-size: 11px;
+  color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ps-run-bar {
+    transition: none;
+  }
 }
 
 /* ── Email card ────────────────────────────────────── */


### PR DESCRIPTION
## What

Adds a **Run backtest** subsection to the portfolio settings Details card (Q2) with:
- A **Rerun** button that triggers a fresh backtest
- A live progress bar + percentage while running
- Success ("Run completed. Portfolio updated.") and inline error feedback
- Portfolio query invalidation on success so the page (incl. "Last run") refreshes

Reuses the existing `usePortfolioRunProgress` composable (SSE + polling backstop) for consistency with the onboarding/recalculating flows.

## Also

- Fixes `triggerPortfolioRun` to `POST /portfolios/{slug}/run` (singular) per the OpenAPI spec; the plural `/runs` is GET-only run history. The function was unused elsewhere.
- Adds a mock handler for `POST /portfolios/:slug/run` so the flow works in mock mode.

## Verification

Lint and typecheck pass. Drove the full flow headlessly via Playwright against the mock backend (idle → running → completed), no console errors.