### PR TITLE
fix: prevent SegmentedControl buttons from submitting forms

### DIFF
--- a/src/components/ui/SegmentedControl.vue
+++ b/src/components/ui/SegmentedControl.vue
@@ -42,6 +42,7 @@ onBeforeUnmount(() => window.removeEventListener('resize', updateIndicator))
       v-for="opt in options"
       :key="opt.key"
       :class="{ active: modelValue === opt.key }"
+      type="button"
       @click="emit('update:modelValue', opt.key)"
     >
       {{ opt.label }}


### PR DESCRIPTION
## Summary
- `<button>` elements default to `type="submit"` inside a `<form>`, so clicking any option in `SegmentedControl` (e.g. email frequency during portfolio creation) was submitting the form prematurely.
- Added `type="button"` to the buttons in `SegmentedControl.vue` to prevent this.

## Test plan
- [ ] Open the Create Portfolio flow and expand the Email Alerts section
- [ ] Click each frequency option — confirm the form is not submitted
- [ ] Verify the selected frequency highlights correctly
- [ ] Confirm the form still submits normally via the submit button